### PR TITLE
Implement integral2/sum2 for ultraSEM.Sol

### DIFF
--- a/+ultraSEM/@Sol/integral2.m
+++ b/+ultraSEM/@Sol/integral2.m
@@ -1,0 +1,42 @@
+function I = integral2(f, varargin)
+%INTEGRAL2   Double integral of an ULTRASEM.SOL.
+%   I = INTEGRAL2(F) returns the double integral of the ULTRASEM.SOL F over
+%   its domain.
+%
+%   I = INTEGRAL2(F, 'all') returns an array of double integrals over each
+%   patch of F.
+%
+% See also SUM2.
+
+% Parse arguments.
+reduce = true;
+if ( nargin == 2 && strcmp(varargin{1}, 'all') )
+    reduce = false;
+end
+
+% Empty check:
+if ( isempty(f) )
+    I = 0;
+    return
+end
+
+% If a patch uses an N x N discretization, then quadrature is performed on
+% that patch using N points.
+I = zeros(length(f),1);
+for k = 1:length(f)
+    [ny,nx] = size(f.coeffs{k});
+    qx = nx; qy = ny;
+    U = zeros(qy,qx);
+    U(1:ny,1:nx) = f.coeffs{k}; U = U(1:qy,1:qx);
+    V = util.coeffs2vals( util.coeffs2vals(U).' ).';
+    wx = util.quadwts(qx); wx = wx(:);
+    wy = util.quadwts(qy); wy = wy(:);
+    I(k) = sum(sum(V .* wy .* wx.'));
+end
+
+% Combine norms on each element.
+if ( reduce )
+    I = sum(I);
+end
+
+end

--- a/+ultraSEM/@Sol/sum2.m
+++ b/+ultraSEM/@Sol/sum2.m
@@ -1,4 +1,4 @@
-function I = sum2(f)
+function I = sum2(f, varargin)
 %SUM2   Double integral of an ULTRASEM.SOL.
 %   I = SUM2(F) returns the double integral of the ULTRASEM.SOL F over its
 %   domain.
@@ -8,6 +8,6 @@ function I = sum2(f)
 %
 % See also INTEGRAL2.
 
-I = integral2(f);
+I = integral2(f, varargin);
 
 end

--- a/+ultraSEM/@Sol/sum2.m
+++ b/+ultraSEM/@Sol/sum2.m
@@ -1,0 +1,13 @@
+function I = sum2(f)
+%SUM2   Double integral of an ULTRASEM.SOL.
+%   I = SUM2(F) returns the double integral of the ULTRASEM.SOL F over its
+%   domain.
+%
+%   I = SUM2(F, 'all') returns an array of double integrals over each patch
+%   of F.
+%
+% See also INTEGRAL2.
+
+I = integral2(f);
+
+end


### PR DESCRIPTION
This PR implements `integral2` and `sum2` for `ultraSEM.Sol`. On each patch, bivariate Clenshaw-Curtis quadrature is used at N+1 x N+1 points, where N is the degree of polynomial approximation on that patch.