### PR TITLE
Implement .*, .^, sqrt()

### DIFF
--- a/+ultraSEM/@Sol/compose.m
+++ b/+ultraSEM/@Sol/compose.m
@@ -5,18 +5,28 @@ function f = compose(op, f, g)
 %   applied to F in value space.
 %
 %   COMPOSE(OP, F, G) returns an ULTRASEM.SOL representing OP(F, G), where
-%   OP is a function handle and F and G are ULTRASEM.SOLs. The function
-%   handle OP is applied to F and G in value space.
+%   OP is a function handle and at least one of F and G is an ULTRASEM.SOL.
+%   The function handle OP is applied to F and G in value space.
 
 %   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
 
-ff = coeffs2vals(f.coeffs);
-
 if ( nargin == 2 )
+    ff = coeffs2vals(f.coeffs);
     ff = cellfun(op, ff, 'UniformOutput', false);
-else
+elseif ( isa(f, 'ultraSEM.Sol') && isa(g, 'ultraSEM.Sol') )
+    % F and G are both ULTRASEM.SOLs:
+    ff = coeffs2vals(f.coeffs);
     gg = coeffs2vals(g.coeffs);
     ff = cellfun(op, ff, gg, 'UniformOutput', false);
+elseif ( isa(f, 'ultraSEM.Sol') )
+    % G is not an ULTRASEM.SOL:
+    ff = coeffs2vals(f.coeffs);
+    ff = cellfun(@(x) op(x,g), ff, 'UniformOutput', false);
+elseif ( isa(g, 'ultraSEM.Sol') )
+    % F is not an ULTRASEM.SOL:
+    gg = coeffs2vals(g.coeffs);
+    ff = cellfun(@(x) op(f,x), gg, 'UniformOutput', false);
+    f = g;
 end
 
 f.coeffs = vals2coeffs(ff);

--- a/+ultraSEM/@Sol/mtimes.m
+++ b/+ultraSEM/@Sol/mtimes.m
@@ -1,29 +1,25 @@
-function T = mtimes(T, c)
+function f = mtimes(f, c)
 %*   Scale an ULTRASEM.SOL.
-%   C*T will scale the ULTRASEM.SOL by C. C must be a scalar.
+%   c*F or F*c multiplies an ULTRASEM.SOL F by a scalar c.
 %
 %   See also TIMES.
 
 %   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
 
-if ( ~isa(T, 'ultraSEM.Sol') )
-    % Ensure T is the ULTRASEM.SOL:
-    T = mtimes(c, T);
+if ( ~isa(f, 'ultraSEM.Sol') )
+    % Ensure F is the ULTRASEM.SOL:
+    f = mtimes(c, f);
     return
 elseif ( isa(c, 'ultraSEM.Sol' ) )
-    % We can't multiply two ULTRASEM.SOLs:
+    % MTIMES should not be used to multiply two ULTRASEM.SOLs:
     error('ULTRASEM:SOL:mtimes:twosols', ...
-        'Cannot multiply (* or .*) two ultraSEM.Sols.\n')
-elseif ( ~isnumeric(c) )
-    error('ULTRASEM:SOL:mtimes:unknown', ...
-        'Cannot multiply an object of type %s by an ultraSEM.Sol.', ...
-        class(c));
-elseif ( ~isscalar(c) )
-    error('ULTRASEM:SOL:mtimes:scalar', ...
-        'C must be a scalar.')
+        ['Cannot multiply two ultraSEM.Sols with ''*''. ', ...
+         'Did you mean ''.*''?\n'])
+elseif ( isnumeric(c) && isscalar(c) )
+    % Multiply ULTRASEM.SOL F by scalar c:
+    f.coeffs = cellfun(@(coeffs) c*coeffs, f.coeffs, 'UniformOutput', false);
+else
+    error('ULTRASEM:SOL:mtimes:invalid', 'c must be a scalar.')
 end
-
-% Scale the solution:
-T.coeffs = cellfun(@(coeffs) c*coeffs, T.coeffs, 'UniformOutput', false);
 
 end

--- a/+ultraSEM/@Sol/power.m
+++ b/+ultraSEM/@Sol/power.m
@@ -1,0 +1,19 @@
+function f = power(f, g)
+%.^   Pointwise power of an ULTRASEM.SOL.
+%   F.^G returns an ULTRASEM.SOL F to the scalar power G, a scalar F to the
+%   ULTRASEM.SOL power G, or an ULTRASEM.SOL F to the ULTRASEM.SOL power G.
+%
+%   See also COMPOSE.
+
+%   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
+
+if ( isempty(f) )
+    return
+elseif ( isempty(g) )
+    f = g;
+    return
+else
+    f = compose(@power, f, g);
+end
+
+end

--- a/+ultraSEM/@Sol/sqrt.m
+++ b/+ultraSEM/@Sol/sqrt.m
@@ -1,0 +1,16 @@
+function f = sqrt(f)
+%SQRT   Square root of an ULTRASEM.SOL.
+%   SQRT(F) returns the square root of an ULTRASEM.SOL F.
+%
+%   See also POWER, COMPOSE.
+
+%   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
+
+% Empty check:
+if ( isempty(f) )
+    return
+end
+
+f = compose(@sqrt, f);
+
+end

--- a/+ultraSEM/@Sol/times.m
+++ b/+ultraSEM/@Sol/times.m
@@ -1,11 +1,26 @@
-function varargout = times(varargin)
-%.*   Scale an ULTRASEM.SOL.
-%   C.*T will scale the ULTRASEM.SOL by C. C must be a scalar.
+function f = times(f, g)
+%.*   Pointwise multiplication for ULTRASEM.SOL.
+%   F.*G multiplies F and G, where F and G may be ULTRASEM.SOL objects or
+%   scalars.
 %
-%   See also MTIMES.
+%   See also MTIMES, COMPOSE.
 
 %   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
 
-[varargout{1:nargout}] = mtimes(varargin{:});
+if ( ~isa(f, 'ultraSEM.Sol') )
+    % Ensure F is the ULTRASEM.SOL:
+    f = times(g, f);
+    return
+elseif ( isa(g, 'ultraSEM.Sol' ) )
+    % Multiply two ULTRASEM.SOLs:
+    % TODO: Check that F and G have the same domain.
+    f = compose(@times, f, g);
+elseif ( isnumeric(g) && isscalar(g) )
+    % Multiply ULTRASEM.SOL F by scalar G:
+    f.coeffs = cellfun(@(coeffs) g*coeffs, f.coeffs, 'UniformOutput', false);
+else
+    error('ULTRASEM:SOL:times:invalid', ...
+        'F and G must be scalars or ultraSEM.Sol objects.')
+end
 
 end


### PR DESCRIPTION
This PR overloads a few MATLAB functions for `ultraSEM.Sol`:

* `f.*g` can do pointwise multiplication of two `ultraSEM.Sol`s.
* `f.^g` can compute powers when `f` or `g` are `ultraSEM.Sol`s.
* `sqrt(f)` is overloaded.