### PR TITLE
Implement Neumann/Robin BCs

### DIFF
--- a/+ultraSEM/@BC/BC.m
+++ b/+ultraSEM/@BC/BC.m
@@ -1,0 +1,89 @@
+classdef BC < matlab.mixin.Heterogeneous
+%ULTRASEM.BC   Boundary condition object from the ULTRASEM system.
+
+%   Copyright 2020 Dan Fortunato, Nick Hale, and Alex Townsend.
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS PROPERTIES:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    % The properties in the BC object correspond to the boundary condition:
+    %
+    %    dir(k)*u + neu(k)*du/dn = val
+
+    properties ( Access = public )
+
+        dir
+        neu
+        val
+
+    end
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% CLASS CONSTRUCTOR:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    methods
+
+        function obj = BC(val, scl)
+
+            if ( nargin == 0 )
+                return
+            end
+
+            if ( nargin == 1 )
+                % Default to Dirichlet boundary conditions:
+                scl = [1 0];
+            end
+
+            if ( isnumeric(scl) && (isscalar(scl) || (isvector(scl) && length(scl)==2) ) )
+                if ( isscalar(scl) )
+                    obj.dir = scl;
+                    obj.neu = scl;
+                else
+                    obj.dir = scl(1);
+                    obj.neu = scl(2);
+                end
+            else
+                error('ULTRASEM:BC:bc:invalid', ...
+                    'Invalid constants in boundary condition.');
+            end
+
+            obj.val = val;
+
+        end
+
+    end
+
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %% STATIC METHODS:
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+    methods ( Access = public, Static = true )
+
+        function bc = dirichlet(val)
+        %DIRICHLET   Construct Dirichlet boundary conditions.
+        %   ULTRASEM.BC.DIRICHLET(VAL) constructs an ULTRASEM.BC
+        %   representing a Dirichlet boundary condition with boundary data
+        %   VAL.
+            bc = ultraSEM.BC(val, [1 0]);
+        end
+
+        function bc = neumann(val)
+        %NEUMANN   Construct Neumann boundary conditions.
+        %   ULTRASEM.BC.NEUMANN(VAL) constructs an ULTRASEM.BC representing
+        %   a Neumann boundary condition with boundary data VAL.
+            bc = ultraSEM.BC(val, [0 1]);
+        end
+
+        function bc = robin(val, a, b)
+        %ROBIN   Construct Robin boundary conditions.
+        %   ULTRASEM.BC.ROBIN(VAL, A, B) constructs an ULTRASEM.BC
+        %   representing the Robin boundary condition A + B*d/dn with
+        %   boundary data VAL and constants A and B.
+            bc = ultraSEM.BC(val, [a b]);
+        end
+
+    end
+
+end

--- a/@ultraSEM/bc2coeffs.m
+++ b/@ultraSEM/bc2coeffs.m
@@ -10,28 +10,71 @@ assert(isBuilt(S), 'ultraSEM object must be built before creating BCs.');
 % Get boundary points:
 edges = S.patches{1}.edges; % TODO: Breaks encapsulation
 
-% Initialize boundary data. We should have n coefficients for
-% each boundary.
-coeffs = cell(size(edges));
-if ( ~isnumeric(bc) )
-    % Evaluate the BC if given a function handle:
-    for k = 1:size(coeffs, 1)
-        % Create grid on this edge:
-        a = edges(k,1)+edges(k,2)*1i;
-        b = edges(k,3)+edges(k,4)*1i;
-        t = chebpts(edges(k,5));
-        x = real(b-a)/2*t+real(b+a)/2;
-        y = imag(b-a)/2*t+imag(b+a)/2;
-        % Evaluate at grid:
-        vals = feval(bc, x, y);
-        % Convert from values to coeffs:
-        coeffs{k} = util.vals2coeffs(vals);
+% Initialize boundary data:
+coeffs = cell(size(edges,1),1);
+
+if ( isa(bc, 'ultraSEM.BC') )
+
+    if ( length(bc) == 1 )
+        % If given a single BC object, replicate it to match the number of
+        % boundaries.
+        bc = repelem(bc, length(coeffs));
     end
-elseif ( isscalar(bc) )
-    % Convert a scalar to coeffs:
+
+    if ( length(bc) == length(coeffs) )
+        % TODO: The use of S.patches{1}.D2N and edges breaks encapsulation.
+        D2N = S.patches{1}.D2N;
+        nn = sum(edges(:,5));
+        A = eye(nn);
+        bcval = zeros(nn, 1);
+        idx = 0;
+
+        % TODO: Detect pure Neumann boundary conditions.
+        for k = 1:size(coeffs, 1)
+            if ( isempty(bc(k).dir) || isempty(bc(k).neu) || ...
+                 isempty(bc(k).val) || (bc(k).dir == 0 && bc(k).neu == 0) )
+                error('ULTRASEM:ULTRASEM:bc2coeffs:unspecified', ...
+                    'Unspecified boundary condition at position %i.', k);
+            end
+            n = edges(k,5);
+            side = (idx+1):(idx+n);
+
+            % Construct the operator that maps from Dirichlet data to mixed
+            % boundary data on this boundary:
+            A(side,:) = bc(k).dir*A(side,:) + bc(k).neu*D2N(side,1:end-1);
+
+            % Get the coefficients of the boundary data:
+            cfs = toCoeffs(bc(k).val, edges(k,:));
+
+            % If there was a Neumann contribution on this boundary, we must
+            % subtract off the normal derivative of the particular
+            % solution.
+            bcval(side) = cfs - bc(k).neu*D2N(side,end);
+            idx = idx + n;
+        end
+
+        % Map the given mixed boundary data to pure Dirichlet data:
+        bc = A \ bcval;
+    else
+        error('ULTRASEM:ULTRASEM:bc2coeffs:length', ...
+            ['The number of boundary conditions does not match the' ...
+             'number of boundaries.']);
+    end
+
+end
+
+if ( ~isnumeric(bc) || isscalar(bc) )
+    for k = 1:size(coeffs, 1)
+        coeffs{k} = toCoeffs(bc, edges(k,:));
+    end
+elseif ( isvector(bc) )
+    % We were given a vector, so assume these are coefficients.
+    idx = 0;
     for k = 1:size(coeffs, 1)
         n = edges(k,5);
-        coeffs{k} = [bc ; zeros(n-1, 1)];
+        side = (idx+1):(idx+n);
+        coeffs{k} = bc(side);
+        idx = idx + n;
     end
 else
     error('ULTRASEM:ULTRASEM:bc2coeffs:badBC', ...
@@ -40,5 +83,32 @@ end
 
 % CAT() is 10x faster than CELL2MAT().
 coeffs = cat(1, coeffs{:});
+
+end
+
+function coeffs = toCoeffs(bc, edge)
+%TOCOEFFS   Convert boundary data to Chebyshev coefficients.
+%   TOCOEFFS(BC, EDGE) converts the boundary data BC along the boundary
+%   EDGE to a vector of univariate Chebyshev coefficients. BC may be a
+%   function handle, a chebfun2, or scalar. EDGE is a row vector that
+%   conforms to the structure of ultraSEM.Patch.edges.
+
+if ( ~isnumeric(bc) )
+    % Evaluate the BC if given a function handle:
+    % Create grid on this edge:
+    a = edge(1)+edge(2)*1i;
+    b = edge(3)+edge(4)*1i;
+    t = chebpts(edge(5));
+    x = real(b-a)/2*t+real(b+a)/2;
+    y = imag(b-a)/2*t+imag(b+a)/2;
+    % Evaluate at grid:
+    vals = feval(bc, x, y);
+    % Convert from values to coeffs:
+    coeffs = util.vals2coeffs(vals);
+elseif ( isscalar(bc) )
+    % Convert a scalar to coeffs:
+    n = edge(5);
+    coeffs = [bc ; zeros(n-1, 1)];
+end
 
 end


### PR DESCRIPTION
This partly implements the feature request in #36. It introduces a new object, `ultraSEM.BC`, for managing the specification of boundary conditions as Dirichlet, Neumann, or Robin.

The following now works:
```
n = 20;
rhs = -1;
pdo = {1, 0, 0};
dom = ultraSEM.rectangle([-2 2 -1 1], 1, 2);
S = ultraSEM(dom, pdo, rhs, n);

% The ordering of the BCs should match the ordering of S.patches{1}.edges
bc = ultraSEM.BC;
bc(1:6) = ultraSEM.BC.dirichlet(0);
bc(4)   = ultraSEM.BC.neumann(0);

u = S \ bc;
```
<img width="492" alt="Screen Shot 2021-02-06 at 12 48 42 AM" src="https://user-images.githubusercontent.com/878034/107110353-2805c200-6815-11eb-9ad1-a9d8b12cc16d.png">
